### PR TITLE
LP-18+App-Label-ist-"LuftpostAndroid"

### DIFF
--- a/LuftpostAndroid/app/src/main/res/values/strings.xml
+++ b/LuftpostAndroid/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">LuftpostAndroid</string>
+    <string name="app_name">Luftpost</string>
 </resources>


### PR DESCRIPTION
`app_name` von "LuftpostAndroid" zu "Luftpost" geändert